### PR TITLE
Bugfix: Request.Body is not seekable

### DIFF
--- a/src/Raygun.Owin/Owin/OwinRequestExtensions.cs
+++ b/src/Raygun.Owin/Owin/OwinRequestExtensions.cs
@@ -4,7 +4,7 @@
     using System.Text;
 
     using Raygun.Owin.Infrastructure;
-
+    using Raygun.Builders;
     internal static class OwinRequestExtensions
     {
         /// <summary>
@@ -16,18 +16,23 @@
             var form = request.Get<IFormCollection>("Microsoft.Owin.Form#collection");
             if (form == null)
             {
-                request.Body.Seek(0, SeekOrigin.Begin);
+                
+                var str = request.CreateBufferedRequestBodyAsync();
+                str.Wait();
+                // not allowed:
+                //request.Body.Seek(0, SeekOrigin.Begin);
 
                 string text;
 
                 // Don't close, it prevents re-winding.
-                using (var reader = new StreamReader(request.Body, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 4 * 1024, leaveOpen: true))
+                using (var reader = new StreamReader(str.Result))
                 {
                     text = reader.ReadToEnd();
                 }
 
                 // re-wind for the next caller
-                request.Body.Seek(0, SeekOrigin.Begin);
+                // not allowed:
+                //request.Body.Seek(0, SeekOrigin.Begin);
 
                 form = OwinHelpers.GetForm(text);
                 request.Set("Microsoft.Owin.Form#collection", form);
@@ -54,4 +59,5 @@
             return text;
         }
     }
+
 }

--- a/src/Raygun.Owin/Raygun.Owin.csproj
+++ b/src/Raygun.Owin/Raygun.Owin.csproj
@@ -35,6 +35,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\CommonAssemblyInfo.cs">


### PR DESCRIPTION
Hey! This is an important bug fix (since the Middleware crashes on this).

The request.Body is not seekable and will therefor throw a NotSupportedException when you try to do it in Body.ReadForm().

This PR is a bit ugly/hack, and should be cleaned up. However, it _runs on my machine_ and I wanted to make you aware of the issue and suggest a solution.
